### PR TITLE
fix(p3): downgrade per-crown log to debug and document quality_flag in docstring

### DIFF
--- a/projects/p3_itc_delineation/src/metrics.py
+++ b/projects/p3_itc_delineation/src/metrics.py
@@ -45,6 +45,7 @@ def extract_tree_metrics(
     -------
     GeoDataFrame
         Input dataframe augmented with ``max_height_m``, ``mean_height_m``,
+        ``quality_flag`` (0 = OK, 1 = extraction failed),
         ``dbh_inches``, and ``stem_volume_cuft`` columns.
     """
     chm_path = Path(chm_path)
@@ -69,7 +70,7 @@ def extract_tree_metrics(
                     mean_heights.append(0.0)
                 quality_flags.append(0)
             except (ValueError, IndexError, rasterio.errors.RasterioError) as exc:
-                logger.warning("Could not extract metrics for crown: %s", exc)
+                logger.debug("Could not extract metrics for crown: %s", exc)
                 max_heights.append(0.0)
                 mean_heights.append(0.0)
                 quality_flags.append(1)

--- a/projects/p3_itc_delineation/src/metrics.py
+++ b/projects/p3_itc_delineation/src/metrics.py
@@ -12,6 +12,7 @@ from typing import Any
 import geopandas as gpd
 import numpy as np
 import rasterio
+import rasterio.errors
 import rasterio.mask
 
 from shared.utils.allometry import dbh_from_crown_diameter, stem_volume_cuft
@@ -50,6 +51,8 @@ def extract_tree_metrics(
 
     max_heights: list[float] = []
     mean_heights: list[float] = []
+    quality_flags: list[int] = []
+    error_count = 0
 
     with rasterio.open(chm_path) as src:
         for _, row in crowns_gdf.iterrows():
@@ -64,14 +67,23 @@ def extract_tree_metrics(
                 else:
                     max_heights.append(0.0)
                     mean_heights.append(0.0)
-            except (ValueError, IndexError) as exc:
+                quality_flags.append(0)
+            except (ValueError, IndexError, rasterio.errors.RasterioError) as exc:
                 logger.warning("Could not extract metrics for crown: %s", exc)
                 max_heights.append(0.0)
                 mean_heights.append(0.0)
+                quality_flags.append(1)
+                error_count += 1
+
+    if error_count > 0:
+        logger.warning(
+            "Metric extraction failed for %d of %d crowns", error_count, len(crowns_gdf)
+        )
 
     result = crowns_gdf.copy()
     result["max_height_m"] = max_heights
     result["mean_height_m"] = mean_heights
+    result["quality_flag"] = quality_flags
 
     # Allometric estimates
     cd_m = result["crown_diameter_m"].values.astype(np.float64)

--- a/projects/p3_itc_delineation/tests/test_metrics.py
+++ b/projects/p3_itc_delineation/tests/test_metrics.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import geopandas as gpd
 import numpy as np
 import pytest
+from shapely.geometry import box
 
 
 class TestExtractTreeMetrics:
@@ -71,6 +72,60 @@ class TestExtractTreeMetrics:
         result = extract_tree_metrics(crowns_gdf, chm_path, default_config)
         if len(result) > 0:
             assert np.all(result["stem_volume_cuft"].values >= 0)
+
+    def test_quality_flag_column_exists(
+        self, crowns_gdf: gpd.GeoDataFrame, chm_path: Path, default_config: dict
+    ):
+        """Output must contain a quality_flag column with 0 for valid data."""
+        from projects.p3_itc_delineation.src.metrics import extract_tree_metrics
+
+        result = extract_tree_metrics(crowns_gdf, chm_path, default_config)
+        assert "quality_flag" in result.columns
+        if len(result) > 0:
+            assert np.all(result["quality_flag"].values == 0)
+
+
+class TestQualityFlags:
+    """Verify quality flag behaviour for invalid and edge-case inputs."""
+
+    def test_invalid_crown_polygon(self, chm_path: Path, default_config: dict):
+        """A polygon outside the CHM extent should get quality_flag=1."""
+        from projects.p3_itc_delineation.src.metrics import extract_tree_metrics
+
+        # Create a crown polygon far outside the CHM extent
+        far_away = box(999_999, 999_999, 1_000_010, 1_000_010)
+        gdf = gpd.GeoDataFrame(
+            {
+                "tree_id": [1],
+                "crown_area_m2": [100.0],
+                "crown_diameter_m": [11.28],
+            },
+            geometry=[far_away],
+            crs="EPSG:3310",
+        )
+
+        result = extract_tree_metrics(gdf, chm_path, default_config)
+        assert isinstance(result, gpd.GeoDataFrame)
+        assert result["quality_flag"].iloc[0] == 1
+        assert result["max_height_m"].iloc[0] == 0.0
+        assert result["mean_height_m"].iloc[0] == 0.0
+
+    def test_empty_geodataframe(self, chm_path: Path, default_config: dict):
+        """An empty GeoDataFrame should return empty output with all columns."""
+        from projects.p3_itc_delineation.src.metrics import extract_tree_metrics
+
+        empty_gdf = gpd.GeoDataFrame(
+            {"tree_id": [], "crown_area_m2": [], "crown_diameter_m": []},
+            geometry=[],
+            crs="EPSG:3310",
+        )
+
+        result = extract_tree_metrics(empty_gdf, chm_path, default_config)
+        assert isinstance(result, gpd.GeoDataFrame)
+        assert len(result) == 0
+        for col in ("max_height_m", "mean_height_m", "quality_flag", "dbh_inches",
+                     "stem_volume_cuft"):
+            assert col in result.columns
 
 
 class TestAllometryValues:


### PR DESCRIPTION
Review feedback on the quality-flag PR flagged two issues in `extract_tree_metrics()`:

- **Log verbosity**: per-crown `logger.warning` on each extraction failure could spam logs on large datasets. Downgraded to `logger.debug`; the aggregate summary warning remains.
- **Docstring gap**: `Returns` section omitted `quality_flag`. Added `quality_flag` (0 = OK, 1 = extraction failed) to the documented output schema.